### PR TITLE
Feat: Implement API-driven frontend with backend validation

### DIFF
--- a/Sri/boring-todo/boring-todo-app/src/app/page.tsx
+++ b/Sri/boring-todo/boring-todo-app/src/app/page.tsx
@@ -6,51 +6,147 @@ import TodoItemAdd from "./todo-item/todo-item-add";
 import TodoList from "./todo-list/todo-list";
 import { useEffect, useState } from "react";
 
+const API_BASE_URL = "http://localhost:8000";
+
 export default function Home() {
   const [todos, setTodos] = useState<Array<TodoItem>>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    const fetchTodos = async () => {
-      try {
-        const response = await fetch("http://localhost:8000/items");
-        const data = await response.json();
-        setTodos(data);
-      } catch (error) {
-        console.error("Error fetching todos:", error);
-      }
-    };
-
     fetchTodos();
   }, []);
 
-  const handleSubmit = (text: string) => {
-    const newTodo: TodoItem = { text, completed: false };
-    setTodos([newTodo, ...todos]);
-  };
-
-  const handleRemove = (index: number) => {
-    setTodos(todos.filter((_, i) => i !== index));
-  };
-
-  const handleToggle = (index: number) => {
-    setTodos(todos.map((item, i) => {
-      if (i === index) {
-        return { ...item, completed: !item.completed };
+  const fetchTodos = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await fetch(`${API_BASE_URL}/items`);
+      if (!response.ok) {
+        throw new Error(`Failed to fetch todos: ${response.statusText}`);
       }
-      return item;
-    }));
+      const data = await response.json();
+      setTodos(data);
+    } catch (error) {
+      console.error("Error fetching todos:", error);
+      setError("Failed to load todos. Make sure the API server is running! 🚨");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleSubmit = async (text: string) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await fetch(`${API_BASE_URL}/items`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ text, completed: false }),
+      });
+      
+      if (!response.ok) {
+        throw new Error(`Failed to create todo: ${response.statusText}`);
+      }
+      
+      const newTodo = await response.json();
+      setTodos([newTodo, ...todos]);
+    } catch (error) {
+      console.error("Error creating todo:", error);
+      setError("Failed to create todo. Arrr! 🏴‍☠️");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleRemove = async (id: string) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await fetch(`${API_BASE_URL}/items/${id}`, {
+        method: "DELETE",
+      });
+      
+      if (!response.ok) {
+        throw new Error(`Failed to delete todo: ${response.statusText}`);
+      }
+      
+      setTodos(todos.filter(todo => todo.id !== id));
+    } catch (error) {
+      console.error("Error deleting todo:", error);
+      setError("Failed to delete todo. Shiver me timbers! ⚔️");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleToggle = async (id: string) => {
+    const todoToUpdate = todos.find(todo => todo.id === id);
+    if (!todoToUpdate) return;
+
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await fetch(`${API_BASE_URL}/items/${id}`, {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ completed: !todoToUpdate.completed }),
+      });
+      
+      if (!response.ok) {
+        throw new Error(`Failed to update todo: ${response.statusText}`);
+      }
+      
+      const updatedTodo = await response.json();
+      setTodos(todos.map(todo => 
+        todo.id === id ? updatedTodo : todo
+      ));
+    } catch (error) {
+      console.error("Error updating todo:", error);
+      setError("Failed to update todo. Batten down the hatches! 🌊");
+    } finally {
+      setLoading(false);
+    }
   };
 
   return (
     <div className={styles.page}>
+      {error && (
+        <div style={{ 
+          color: 'red', 
+          padding: '10px', 
+          marginBottom: '10px', 
+          border: '1px solid red', 
+          borderRadius: '4px',
+          backgroundColor: '#ffe6e6'
+        }}>
+          {error}
+        </div>
+      )}
+      {loading && (
+        <div style={{ 
+          color: 'blue', 
+          padding: '10px', 
+          marginBottom: '10px',
+          textAlign: 'center'
+        }}>
+          Loading... ⚓
+        </div>
+      )}
       <TodoItemAdd
         dataSource={todos}
         onSubmitted={handleSubmit}
+        disabled={loading}
       />
       <TodoList
         dataSource={todos}
         onItemRemoved={handleRemove}
         onItemToggle={handleToggle}
+        disabled={loading}
       />
     </div>
   );

--- a/Sri/boring-todo/boring-todo-app/src/app/todo-item/todo-item-add.tsx
+++ b/Sri/boring-todo/boring-todo-app/src/app/todo-item/todo-item-add.tsx
@@ -4,19 +4,23 @@ import { TodoItem } from "./todo-item-type";
 interface Props {
     dataSource: Array<TodoItem>;
     onSubmitted: (text: string) => void;
+    disabled?: boolean;
 }
 
 /**
  * A React component that renders an input field for adding new todo items.
  * 
- * @param dataSource - Array of existing todo items to che∏k for duplicates
+ * @param dataSource - Array of existing todo items to check for duplicates
  * @param onSubmitted - Callback function triggered when a valid todo item is submitted
+ * @param disabled - Whether the input should be disabled during loading
  * @returns Input element that handles todo item addition on Enter key press
  */
 export default function TodoItemAdd(
-    { dataSource, onSubmitted }: Props
+    { dataSource, onSubmitted, disabled = false }: Props
 ) {
     const onKeyUp = (e: React.KeyboardEvent<HTMLInputElement>) => {
+        if (disabled) return;
+        
         e.preventDefault();
         if (e.key === "Enter") {
             let text = (e.target as HTMLInputElement).value;
@@ -39,7 +43,8 @@ export default function TodoItemAdd(
             className={styles.todo_item_add}
             autoFocus
             type="text"
-            placeholder="create a new task"
+            placeholder={disabled ? "Loading... ⚓" : "create a new task"}
+            disabled={disabled}
             onKeyUp={e => onKeyUp(e)} />
     );
 }

--- a/Sri/boring-todo/boring-todo-app/src/app/todo-item/todo-item-type.tsx
+++ b/Sri/boring-todo/boring-todo-app/src/app/todo-item/todo-item-type.tsx
@@ -1,4 +1,5 @@
 export interface TodoItem {
+    id: string;
     text: string;
     completed: boolean;
 }

--- a/Sri/boring-todo/boring-todo-app/src/app/todo-list/todo-list.tsx
+++ b/Sri/boring-todo/boring-todo-app/src/app/todo-list/todo-list.tsx
@@ -3,12 +3,13 @@ import { TodoItem } from "../todo-item/todo-item-type";
 
 interface Props {
     dataSource: Array<TodoItem>;
-    onItemRemoved: (index: number) => void;
-    onItemToggle: (index: number) => void;
+    onItemRemoved: (id: string) => void;
+    onItemToggle: (id: string) => void;
+    disabled?: boolean;
 }
 
 export default function TodoList(
-    { dataSource, onItemRemoved, onItemToggle }: Props
+    { dataSource, onItemRemoved, onItemToggle, disabled = false }: Props
 ) {
     const listItems = dataSource.map((item, index) => {
         const classNames = ["todo_list_item", styles.todo_list_item];
@@ -16,7 +17,11 @@ export default function TodoList(
             <a
                 className={[styles.todo_list_item_delete, "todo_list_item_delete"].join(" ")}
                 data-testid={`todo_list_item_delete_${index}`}
-                onClick={() => onItemRemoved(index)}>
+                onClick={() => !disabled && onItemRemoved(item.id)}
+                style={{ 
+                    opacity: disabled ? 0.5 : 1, 
+                    cursor: disabled ? 'not-allowed' : 'pointer' 
+                }}>
                 🗑️
             </a>);
         if (item.completed) {
@@ -24,13 +29,23 @@ export default function TodoList(
             deleteLink = (<></>);
         }
 
+        if (disabled) {
+            classNames.push('disabled');
+        }
+
         return (
             <li className={classNames.join(" ")}
-                key={index}>
+                key={item.id}
+                style={{ opacity: disabled ? 0.7 : 1 }}>
                 <span
                     className="todo_list_item_text"
                     data-testid={`todo_list_item_text_${index}`}
-                    onClick={() => onItemToggle(index)}>{item.text}</span>
+                    onClick={() => !disabled && onItemToggle(item.id)}
+                    style={{ 
+                        cursor: disabled ? 'not-allowed' : 'pointer' 
+                    }}>
+                    {item.text}
+                </span>
                 {deleteLink}
             </li>
         );


### PR DESCRIPTION
### **Grug brained review**
Grug look at code. Before, frontend was play-pretend. It talk to self in mirror. Now, frontend talk to backend over network. This good. This how real cave paintings get made. 🗿

Frontend now have loading spinner ⚓ and show big red scary message when backend angry. This smart. User no click button many times and break things. User see "Loading..." and wait. User see "Error! 🏴‍☠️" and know something bad happen. Less confusion. Less clubbing of computer. Good.

Backend now smarter too. It no accept empty rock carving. It no accept same rock carving twice. It say "No, ye landlubber!". Grug laugh at pirate words. Funny. But also good. Backend protect data. Makes data strong. 💪 This whole change make app less like toy, more like sharp rock. Good for hunting mammoths. Grug approve. 👍


___

### **User description**
Fixes #13


___

### **PR Type**
Enhancement


___

### **Description**
- Refactor frontend to be fully API-driven for all CRUD operations

- Implement loading and error handling states in the UI

- Add backend validation for non-empty and unique todo text

- Enhance API documentation with example schemas


___

### **Changes diagram**

```mermaid
flowchart LR
  subgraph Frontend (React)
      A["Todo App UI (page.tsx)"]
  end
  subgraph Backend (FastAPI)
      B["API Endpoints (main.py)"]
      C["Input Validation"]
  end

  A -- "CRUD API Calls" --> B
  B -- "Validate Data" --> C
  C -- "Raise Exception on Bad Data" --> B
  B -- "Perform Operation" --> B
  B -- "Return JSON Response" --> A
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.py</strong><dd><code>Add robust backend validation and enhance API documentation</code></dd></summary>
<hr>

Sri/boring-todo/boring-todo-api/src/boring_todo_api/main.py

<li>Added input validation to prevent empty or duplicate todo items.<br> <li> Added example schemas to Pydantic models for better API documentation.<br> <li> Updated CORS settings to allow requests from <code>http://localhost:3000</code>.<br> <li> Replaced standard error messages with pirate-themed ones.


</details>


  </td>
  <td><a href="https://github.com/qodo-se/Demos/pull/21/files#diff-5f907ddfdcb6c14f26aa269eeea9e7841bd4b5788bfb693ebfee90d0ee129e3e">+40/-5</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>page.tsx</strong><dd><code>Refactor main page to be fully API-driven with loading and error </code><br><code>handling</code></dd></summary>
<hr>

Sri/boring-todo/boring-todo-app/src/app/page.tsx

<li>Refactored component from local state management to be fully <br>API-driven.<br> <li> Implemented API calls for fetching, creating, deleting, and updating <br>todos.<br> <li> Added <code>loading</code> and <code>error</code> states to provide feedback to the user.<br> <li> UI elements are now disabled during API requests to prevent race <br>conditions.


</details>


  </td>
  <td><a href="https://github.com/qodo-se/Demos/pull/21/files#diff-830dd16cef413e343a0a0cb2fdd087a9f0b55e3b9a1b83b77f8f5debff5bf271">+117/-21</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>todo-item-add.tsx</strong><dd><code>Add disabled state to todo item input component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Sri/boring-todo/boring-todo-app/src/app/todo-item/todo-item-add.tsx

<li>Added a <code>disabled</code> prop to control the input field's state.<br> <li> The input is disabled and shows a "Loading..." placeholder during API <br>calls.


</details>


  </td>
  <td><a href="https://github.com/qodo-se/Demos/pull/21/files#diff-f4f4181c95828f1ef3c83db430bb73ac24cc10ab4e556eed1b66060968a58349">+8/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>todo-item-type.tsx</strong><dd><code>Update TodoItem type to include an ID</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Sri/boring-todo/boring-todo-app/src/app/todo-item/todo-item-type.tsx

- Added an `id` field to the `TodoItem` interface.


</details>


  </td>
  <td><a href="https://github.com/qodo-se/Demos/pull/21/files#diff-2ebf7369ad3ae2c264b5526918fe7a798a07c0e73fbfaa090675648f24966e62">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>todo-list.tsx</strong><dd><code>Refactor todo list to use item IDs and support a disabled state</code></dd></summary>
<hr>

Sri/boring-todo/boring-todo-app/src/app/todo-list/todo-list.tsx

<li>Refactored component to use <code>id</code> for identifying items instead of array <br>index.<br> <li> Added a <code>disabled</code> prop to prevent actions during API calls.<br> <li> Applied visual styles (opacity, cursor) to indicate the disabled <br>state.


</details>


  </td>
  <td><a href="https://github.com/qodo-se/Demos/pull/21/files#diff-824ea366a2f77c58fcb1054f45df05ce0a0761d51ec9d57e407277c88bbda0e7">+21/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table><hr>

<details> <summary><strong>✨ Describe tool usage guide:</strong></summary><hr> 

**Overview:**
The `describe` tool scans the PR code changes, and generates a description for the PR - title, type, summary, walkthrough and labels. The tool can be triggered [automatically](https://pr-agent-docs.codium.ai/usage-guide/automations_and_usage/#github-app-automatic-tools-when-a-new-pr-is-opened) every time a new PR is opened, or can be invoked manually by commenting on a PR.

When commenting, to edit [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml#L46) related to the describe tool (`pr_description` section), use the following template:
```
/describe --pr_description.some_config1=... --pr_description.some_config2=...
```
With a [configuration file](https://pr-agent-docs.codium.ai/usage-guide/configuration_options/), use the following template:
```
[pr_description]
some_config1=...
some_config2=...
```


<table><tr><td><details> <summary><strong> Enabling\disabling automation </strong></summary><hr>

- When you first install the app, the [default mode](https://pr-agent-docs.codium.ai/usage-guide/automations_and_usage/#github-app-automatic-tools-when-a-new-pr-is-opened) for the describe tool is:
```
pr_commands = ["/describe", ...]
```
meaning the `describe` tool will run automatically on every PR.

- Markers are an alternative way to control the generated description, to give maximal control to the user. If you set:
```
pr_commands = ["/describe --pr_description.use_description_markers=true", ...]
```
the tool will replace every marker of the form `pr_agent:marker_name` in the PR description with the relevant content, where `marker_name` is one of the following:
  - `type`: the PR type.
  - `summary`: the PR summary.
  - `walkthrough`: the PR walkthrough.

Note that when markers are enabled, if the original PR description does not contain any markers, the tool will not alter the description at all.



</details></td></tr>

<tr><td><details> <summary><strong> Custom labels </strong></summary><hr>

The default labels of the `describe` tool are quite generic: [`Bug fix`, `Tests`, `Enhancement`, `Documentation`, `Other`].

If you specify [custom labels](https://pr-agent-docs.codium.ai/tools/describe/#handle-custom-labels-from-the-repos-labels-page) in the repo's labels page or via configuration file, you can get tailored labels for your use cases.
Examples for custom labels:
- `Main topic:performance` - pr_agent:The main topic of this PR is performance
- `New endpoint` - pr_agent:A new endpoint was added in this PR
- `SQL query` - pr_agent:A new SQL query was added in this PR
- `Dockerfile changes` - pr_agent:The PR contains changes in the Dockerfile
- ...

The list above is eclectic, and aims to give an idea of different possibilities. Define custom labels that are relevant for your repo and use cases.
Note that Labels are not mutually exclusive, so you can add multiple label categories.
Make sure to provide proper title, and a detailed and well-phrased description for each label, so the tool will know when to suggest it.


</details></td></tr>

<tr><td><details> <summary><strong> Inline File Walkthrough 💎</strong></summary><hr>

For enhanced user experience, the `describe` tool can add file summaries directly to the "Files changed" tab in the PR page.
This will enable you to quickly understand the changes in each file, while reviewing the code changes (diffs).

To enable inline file summary, set `pr_description.inline_file_summary` in the configuration file, possible values are:
- `'table'`: File changes walkthrough table will be displayed on the top of the "Files changed" tab, in addition to the "Conversation" tab.
- `true`: A collapsable file comment with changes title and a changes summary for each file in the PR.
- `false` (default): File changes walkthrough will be added only to the "Conversation" tab.
<tr><td><details> <summary><strong> Utilizing extra instructions</strong></summary><hr>

The `describe` tool can be configured with extra instructions, to guide the model to a feedback tailored to the needs of your project.

Be specific, clear, and concise in the instructions. With extra instructions, you are the prompter. Notice that the general structure of the description is fixed, and cannot be changed. Extra instructions can change the content or style of each sub-section of the PR description.

Examples for extra instructions:
```
[pr_description]
extra_instructions="""- The PR title should be in the format: '<PR type>: <title>'
- The title should be short and concise (up to 10 words)
- ...
"""
```
Use triple quotes to write multi-line instructions. Use bullet points to make the instructions more readable.


</details></td></tr>



<tr><td><details> <summary><strong> More PR-Agent commands</strong></summary><hr> 

> To invoke the PR-Agent, add a comment using one of the following commands:  
> - **/review**: Request a review of your Pull Request.   
> - **/describe**: Update the PR title and description based on the contents of the PR.   
> - **/improve [--extended]**: Suggest code improvements. Extended mode provides a higher quality feedback.   
> - **/ask \<QUESTION\>**: Ask a question about the PR.   
> - **/update_changelog**: Update the changelog based on the PR's contents.   
> - **/help_docs \<QUESTION\>**: Given a path to documentation (either for this repository or for a given one), ask a question.   
> - **/add_docs** 💎: Generate docstring for new components introduced in the PR.   
> - **/generate_labels** 💎: Generate labels for the PR based on the PR's contents.   
> - **/analyze** 💎: Automatically analyzes the PR, and presents changes walkthrough for each component.   

>See the [tools guide](https://pr-agent-docs.codium.ai/tools/) for more details.
>To list the possible configuration parameters, add a **/config** comment.   
 


</details></td></tr>

</table>

See the [describe usage](https://pr-agent-docs.codium.ai/tools/describe/) page for a comprehensive guide on using this tool.


</details>

